### PR TITLE
Accommodation Bookings 1.0.2: Booking Details Screen

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
@@ -13,7 +13,6 @@ class WC_Accommodation_Booking_Admin_Meta_Box {
 	}
 
 	public function start_time( $time, $post_id ) {
-		$product_id = get_post_meta( $post_id, '_booking_product_id', true );
 		$product = wc_get_product( get_post_meta( $post_id, '_booking_product_id', true ) );
 		if ( 'accommodation-booking' !== $product->product_type ) {
 			return $time;
@@ -23,7 +22,6 @@ class WC_Accommodation_Booking_Admin_Meta_Box {
 	}
 
 	public function end_time( $time, $post_id ) {
-		$product_id = get_post_meta( $post_id, '_booking_product_id', true );
 		$product = wc_get_product( get_post_meta( $post_id, '_booking_product_id', true ) );
 		if ( 'accommodation-booking' !== $product->product_type ) {
 			return $time;

--- a/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
@@ -3,21 +3,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Overwrites pieces of the booking details (edit booking/manage booking) page
+ */
 class WC_Accommodation_Booking_Admin_Meta_Box {
-
 	public function __construct() {
 		add_filter( 'woocommerce_booking_admin_start_time', array( $this, 'start_time' ), 10, 2 );
 		add_filter( 'woocommerce_booking_admin_end_time', array( $this, 'end_time' ), 10, 2 );
 	}
 
-	public function start_time( $time, $product_id ) {
+	public function start_time( $time, $post_id ) {
+		$product_id = get_post_meta( $post_id, '_booking_product_id', true );
+		$product = wc_get_product( get_post_meta( $post_id, '_booking_product_id', true ) );
+		if ( 'accommodation-booking' !== $product->product_type ) {
+			return $time;
+		}
 		$check_in = get_option( 'woocommerce_accommodation_bookings_check_in', '' );
-		return date_i18n( get_option( 'time_format' ), strtotime( "Today " . $check_in ) );
+		return date_i18n( get_option( 'time_format' ), strtotime( 'Today ' . $check_in ) );
 	}
 
-	public function end_time( $time, $product_id ) {
+	public function end_time( $time, $post_id ) {
+		$product_id = get_post_meta( $post_id, '_booking_product_id', true );
+		$product = wc_get_product( get_post_meta( $post_id, '_booking_product_id', true ) );
+		if ( 'accommodation-booking' !== $product->product_type ) {
+			return $time;
+		}
 		$check_out = get_option( 'woocommerce_accommodation_bookings_check_out', '' );
-		return date_i18n( get_option( 'time_format' ), strtotime( "Today " . $check_out ) );
+		return date_i18n( get_option( 'time_format' ), strtotime( 'Today ' . $check_out ) );
 	}
 }
 

--- a/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
@@ -1,0 +1,25 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WC_Accommodation_Booking_Admin_Meta_Box {
+
+	public function __construct() {
+		add_filter( 'woocommerce_booking_admin_start_time', array( $this, 'start_time' ), 10, 2 );
+		add_filter( 'woocommerce_booking_admin_end_time', array( $this, 'end_time' ), 10, 2 );
+	}
+
+	public function start_time( $time, $product_id ) {
+		$check_in = get_option( 'woocommerce_accommodation_bookings_check_in', '' );
+		return date_i18n( get_option( 'time_format' ), strtotime( "Today " . $check_in ) );
+	}
+
+	public function end_time( $time, $product_id ) {
+		$check_out = get_option( 'woocommerce_accommodation_bookings_check_out', '' );
+		return date_i18n( get_option( 'time_format' ), strtotime( "Today " . $check_out ) );
+	}
+}
+
+
+new WC_Accommodation_Booking_Admin_Meta_Box;

--- a/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-meta-box.php
@@ -18,7 +18,7 @@ class WC_Accommodation_Booking_Admin_Meta_Box {
 			return $time;
 		}
 		$check_in = get_option( 'woocommerce_accommodation_bookings_check_in', '' );
-		return date_i18n( get_option( 'time_format' ), strtotime( 'Today ' . $check_in ) );
+		return date_i18n( 'G:i', strtotime( 'Today ' . $check_in ) );
 	}
 
 	public function end_time( $time, $post_id ) {
@@ -27,7 +27,7 @@ class WC_Accommodation_Booking_Admin_Meta_Box {
 			return $time;
 		}
 		$check_out = get_option( 'woocommerce_accommodation_bookings_check_out', '' );
-		return date_i18n( get_option( 'time_format' ), strtotime( 'Today ' . $check_out ) );
+		return date_i18n( 'G:i', strtotime( 'Today ' . $check_out ) );
 	}
 }
 

--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -15,6 +15,7 @@ class WC_Accommodation_Booking {
 		add_filter( 'woocommerce_bookings_product_types', array( $this, 'add_product_type' ) );
 		add_filter( 'woocommerce_bookings_get_start_date_with_time', array( $this, 'add_checkin_time_to_booking_start_time' ), 10, 2 );
 		add_filter( 'woocommerce_bookings_get_end_date_with_time', array( $this, 'add_checkout_time_to_booking_end_time' ), 10, 2 );
+		add_filter( 'get_booking_products_terms', array( $this, 'add_accommodation_to_booking_product_terms' ) );
 	}
 
 	/**
@@ -50,6 +51,14 @@ class WC_Accommodation_Booking {
 		$time_format = apply_filters( 'woocommerce_bookings_time_format', ', ' . wc_time_format() );
 
 		return date_i18n( $date_format, $booking->end ) . date_i18n( $time_format, strtotime( "Today " . $check_out ) );
+	}
+
+	/**
+	 * Adds 'accommodation-booking' to the list of valid product types/terms
+	 */
+	public function add_accommodation_to_booking_product_terms( $terms ) {
+		$terms[] = 'accommodation-booking';
+		return $terms;
 	}
 
 }

--- a/includes/class-wc-product-accommodation-booking.php
+++ b/includes/class-wc-product-accommodation-booking.php
@@ -22,6 +22,22 @@ class WC_Product_Accommodation_Booking extends WC_Product_Booking {
 	}
 
 	/**
+	 * Tells Bookings that this product type is a bookings addon.
+	 * @return boolean
+	 */
+	public function is_bookings_addon() {
+		return true;
+	}
+
+	/**
+	 * Human readable version of the addon title
+	 * @return string
+	 */
+	public function bookings_addon_title() {
+		return __( 'Accommodation booking', 'woocommerce-accommodation-bookings' );
+	}
+
+	/**
 	 * Version 1.0.0 does not support persons/person types yet - just booking rooms
 	 * @return boolean
 	 */

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -78,7 +78,7 @@ class WC_Accommodation_Bookings {
 	public function admin_includes() {
 		include( 'includes/admin/class-wc-accommodation-booking-admin-panels.php' );
 		include( 'includes/admin/class-wc-accommodation-booking-admin-product-settings.php' );
-		include ('includes/admin/class-wc-accommodation-booking-admin-meta-box.php' );
+		include( 'includes/admin/class-wc-accommodation-booking-admin-meta-box.php' );
 	}
 
 	/**

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -78,6 +78,7 @@ class WC_Accommodation_Bookings {
 	public function admin_includes() {
 		include( 'includes/admin/class-wc-accommodation-booking-admin-panels.php' );
 		include( 'includes/admin/class-wc-accommodation-booking-admin-product-settings.php' );
+		include ('includes/admin/class-wc-accommodation-booking-admin-meta-box.php' );
 	}
 
 	/**


### PR DESCRIPTION
This PR makes the "booking details" screen slightly more useful for accommodation bookings.

* The booking type is mentioned at the top of the screen letting you know it is an accommodation.
* Accommodation products are now loaded into the "booked products" drop down.
* Start/end time correctly displays check-in/check-out time from global settings.
* All-day check box has been hidden.

Related: https://github.com/woothemes/woocommerce-bookings/pull/590

Please review @gedex 