### PR TITLE
Add actions for extending the pricing

### DIFF
--- a/includes/admin/views/html-accommodation-booking-rates-fields.php
+++ b/includes/admin/views/html-accommodation-booking-rates-fields.php
@@ -105,6 +105,7 @@
 	</td>
 	<td>
 		<input type="number" step="0.01" name="wc_accommodation_booking_pricing_block_cost[]" value="<?php if ( ! empty( $rate['override_block'] ) ) echo $rate['override_block']; ?>" placeholder="0" />
+		<?php do_action( 'woocommerce_accommodation_bookings_after_booking_pricing_override_block_cost', $rate, $post_id ); ?>
 	</td>
 	<td class="remove">&nbsp;</td>
 </tr>

--- a/includes/admin/views/html-accommodation-booking-rates.php
+++ b/includes/admin/views/html-accommodation-booking-rates.php
@@ -4,6 +4,7 @@
 			'min'   => '',
 			'step' 	=> '0.01'
 		) ) ); ?>
+		<?php do_action( 'woocommerce_accommodation_bookings_after_booking_base_cost', $post_id ); ?>
 	</div>
 	<div class="options_group">
 		<div class="table_grid">
@@ -42,5 +43,6 @@
 				</tbody>
 			</table>
 		</div>
+		<?php do_action( 'woocommerce_accommodation_bookings_after_bookings_pricing', $post_id ); ?>
 	</div>
 </div>


### PR DESCRIPTION
These actions allow extending the functionality around pricing.

Since the accommodation products use a different UI than the standard WooCommerce products it’s not currently possible to customize this to add separate fields for alternative costs.

Actions that allow one to add custom fields for costs:

do_action( 'woocommerce_accommodation_bookings_after_booking_base_cost', $post_id );

allows adding a custom price field (e.g. in a different currency) for Standard room rate cost

do_action( 'woocommerce_accommodation_bookings_after_booking_pricing_override_block_cost', $rate, $post_id );

allows adding a custom price field (e.g. in a different currency) for Range cost


An action that allows hooking into the costs UI below all the costs fields
do_action( 'woocommerce_accommodation_bookings_after_bookings_pricing', $post_id ); 
e.g. display option to enable / disable custom costs for different currencies.