### PR TITLE
Fixed wrong text domain being used.

### DIFF
--- a/includes/admin/views/html-accommodation-booking-data.php
+++ b/includes/admin/views/html-accommodation-booking-data.php
@@ -21,7 +21,7 @@
 		woocommerce_wp_text_input( array(
 			'id'                => '_wc_accommodation_booking_max_duration',
 			'label'             => __( 'Maximum number of nights allowed in a booking', 'woocommerce-accommodation-bookings' ),
-			'description'       => __( 'The maximum allowed duration the user can stay.', 'woocommerce-bookings' ),
+			'description'       => __( 'The maximum allowed duration the user can stay.', 'woocommerce-accommodation-bookings' ),
 			'value'             => ( empty( $max_duration ) ? 7 : $max_duration ),
 			'desc_tip'          => true,
 			'type'              => 'number',

--- a/includes/class-wc-accommodation-booking-order-info.php
+++ b/includes/class-wc-accommodation-booking-order-info.php
@@ -25,7 +25,7 @@ class WC_Accommodation_Booking_Order_Info {
 			return;
 		}
 
-		$booking_date_key = __( 'Booking Date', 'woocommerce-bookings' );
+		$booking_date_key = __( 'Booking Date', 'woocommerce-accommodation-bookings' );
 		$booking_date     = ! empty( $item[ $booking_date_key ] ) ? $item[ $booking_date_key ] : null;
 
 		if ( ! $booking_date ) {
@@ -43,7 +43,7 @@ class WC_Accommodation_Booking_Order_Info {
 			echo esc_html( date_i18n( get_option( 'time_format' ), strtotime( "Today " . $check_in ) ) );
 		}
 
-		$duration_key = __( 'Duration', 'woocommerce-bookings' );
+		$duration_key = __( 'Duration', 'woocommerce-accommodation-bookings' );
 		$duration     = intval( $item[ $duration_key ] );
 		$end_date_ts  = $this->get_end_date_timestamp( $booking_date, $duration );
 		if ( ! $end_date_ts ) {


### PR DESCRIPTION
Fixes #50.

#### Changes proposed in this Pull Request:

Use text domain `woocommerce-accommodation-bookings` to avoid confusion in POT file for translators.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

