### PR TITLE
Set writepanel.js to only be included on product admin pages

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -47,8 +47,12 @@ class WC_Accommodation_Booking_Admin_Panels {
 	 * Loads any CSS or JS necessary for the admin
 	 */
 	public function admin_styles_and_scripts() {
-		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'wc_accommodation_bookings_writepanel_js', WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/assets/js/writepanel' . $suffix . '.js', array( 'jquery' ), WC_ACCOMMODATION_BOOKINGS_VERSION, true );
+
+		// only load it on products
+		if ( 'product' === get_post_type() ) {
+			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+			wp_enqueue_script( 'wc_accommodation_bookings_writepanel_js', WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/assets/js/writepanel' . $suffix . '.js', array( 'jquery' ), WC_ACCOMMODATION_BOOKINGS_VERSION, true );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes # .
No bug open for this.
`writepanel.js` is being included on all admin pages, which causes a JS error on all pages that are not product pages.

![screen shot on 2016-06-07 at 13 3a13 3a25](https://cloud.githubusercontent.com/assets/4634416/15867509/b878dfe2-2cb1-11e6-8718-03cc3a6c3260.png)

#### Changes proposed in this Pull Request:
- Wrapped the enqueue function with if statement checking to make sure the post type is `product`.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


