### PR TITLE
Added Display Cost field to Accommodation product Rates tab

### DIFF
--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -47,8 +47,12 @@ class WC_Accommodation_Booking_Admin_Panels {
 	 * Loads any CSS or JS necessary for the admin
 	 */
 	public function admin_styles_and_scripts() {
-		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'wc_accommodation_bookings_writepanel_js', WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/assets/js/writepanel' . $suffix . '.js', array( 'jquery' ), WC_ACCOMMODATION_BOOKINGS_VERSION, true );
+
+		// only load it on products
+		if ( 'product' === get_post_type() ) {
+			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+			wp_enqueue_script( 'wc_accommodation_bookings_writepanel_js', WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/assets/js/writepanel' . $suffix . '.js', array( 'jquery' ), WC_ACCOMMODATION_BOOKINGS_VERSION, true );
+		}
 	}
 
 	/**
@@ -126,6 +130,7 @@ class WC_Accommodation_Booking_Admin_Panels {
 			'_wc_accommodation_booking_min_date_unit'              => '',
 			'_wc_accommodation_booking_qty'                        => 'int',
 			'_wc_accommodation_booking_base_cost'                  => 'float',
+			'_wc_accommodation_booking_display_cost'               => '',
 			'_wc_accommodation_booking_min_duration'               => 'int',
 			'_wc_accommodation_booking_max_duration'               => 'int',
 		);
@@ -157,6 +162,10 @@ class WC_Accommodation_Booking_Admin_Panels {
 
 			$meta_key = str_replace( '_wc_accommodation_booking_', '_wc_booking_', $meta_key );
 			update_post_meta( $post_id, $meta_key, $value );
+
+			if ( '_wc_booking_display_cost' == $meta_key ) {
+				update_post_meta( $post_id, '_wc_display_cost', $value );
+			}
 		}
 
 		// Availability

--- a/includes/admin/class-wc-accommodation-booking-admin-panels.php
+++ b/includes/admin/class-wc-accommodation-booking-admin-panels.php
@@ -48,8 +48,11 @@ class WC_Accommodation_Booking_Admin_Panels {
 	 */
 	public function admin_styles_and_scripts() {
 
+		// get the current screen
+		$screen = get_current_screen();
+
 		// only load it on products
-		if ( 'product' === get_post_type() ) {
+		if ( 'product' === $screen->id ) {
 			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 			wp_enqueue_script( 'wc_accommodation_bookings_writepanel_js', WC_ACCOMMODATION_BOOKINGS_PLUGIN_URL . '/assets/js/writepanel' . $suffix . '.js', array( 'jquery' ), WC_ACCOMMODATION_BOOKINGS_VERSION, true );
 		}
@@ -163,7 +166,7 @@ class WC_Accommodation_Booking_Admin_Panels {
 			$meta_key = str_replace( '_wc_accommodation_booking_', '_wc_booking_', $meta_key );
 			update_post_meta( $post_id, $meta_key, $value );
 
-			if ( '_wc_booking_display_cost' == $meta_key ) {
+			if ( '_wc_booking_display_cost' === $meta_key ) {
 				update_post_meta( $post_id, '_wc_display_cost', $value );
 			}
 		}

--- a/includes/admin/views/html-accommodation-booking-rates.php
+++ b/includes/admin/views/html-accommodation-booking-rates.php
@@ -5,6 +5,13 @@
 			'step' 	=> '0.01'
 		) ) ); ?>
 		<?php do_action( 'woocommerce_accommodation_bookings_after_booking_base_cost', $post_id ); ?>
+
+		<?php woocommerce_wp_text_input( array( 'id' => '_wc_accommodation_booking_display_cost', 'label' => __( 'Display cost', 'woocommerce-accommodation-bookings' ), 'description' => __( 'The cost is displayed to the user on the frontend. Leave blank to have it calculated for you. If a booking has varying costs, this will be prefixed with the word "from:".', 'woocommerce-accommodation-bookings' ), 'value' => get_post_meta( $post_id, '_wc_display_cost', true ), 'type' => 'number', 'desc_tip' => true, 'custom_attributes' => array(
+			'min'   => '',
+			'step' 	=> '0.01'
+		) ) ); ?>
+
+        <?php do_action( 'woocommerce_accommodation_bookings_after_display_cost', $post_id ); ?>
 	</div>
 	<div class="options_group">
 		<div class="table_grid">


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
- Added Display Cost tab to account for offset mentioned in #60 

![screen shot 2016-07-07 at 13 59 23](https://cloud.githubusercontent.com/assets/4634416/16663967/2e1144c2-444c-11e6-92bd-4d1fae04c1f8.png)

![screen shot 2016-07-07 at 14 00 01](https://cloud.githubusercontent.com/assets/4634416/16663973/37c3ace4-444c-11e6-986f-a37f17168fef.png)


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


