### PR TITLE
When new booking is created, update its start and end time.

### DIFF
--- a/includes/class-wc-accommodation-booking.php
+++ b/includes/class-wc-accommodation-booking.php
@@ -17,6 +17,8 @@ class WC_Accommodation_Booking {
 		add_filter( 'woocommerce_bookings_get_end_date_with_time', array( $this, 'add_checkout_time_to_booking_end_time' ), 10, 2 );
 		add_filter( 'get_booking_products_terms', array( $this, 'add_accommodation_to_booking_product_terms' ) );
 		add_filter( 'get_booking_products_args', array( $this, 'add_accommodation_to_booking_products_args' ) );
+
+		add_action( 'woocommerce_new_booking', array( $this, 'update_start_end_time' ) );
 	}
 
 	/**
@@ -88,6 +90,51 @@ class WC_Accommodation_Booking {
 		return $args;
 	}
 
+	/**
+	 * Update start and end time based on check in/out time.
+	 *
+	 * Since duration of accommodation product is one night, only date is respected
+	 * and check-in/out times are not counted.
+	 *
+	 * @since 1.0.6
+	 *
+	 * @param int $booking_id Booking ID
+	 */
+	public function update_start_end_time( $booking_id ) {
+		$product_id = get_post_meta( $booking_id, '_booking_product_id', true );
+		$product   = wc_get_product( $product_id );
+		if ( ! is_a( $product, 'WC_Product_Accommodation_Booking' ) ) {
+			return;
+		}
+
+		$check_in  = get_option( 'woocommerce_accommodation_bookings_check_in', '' );
+		$check_out = get_option( 'woocommerce_accommodation_bookings_check_out', '' );
+
+		$start = get_post_meta( $booking_id, '_booking_start', true );
+		$end   = get_post_meta( $booking_id, '_booking_end', true );
+
+		update_post_meta( $booking_id, '_booking_start', $this->_get_updated_timestamp_time( $start, $check_in ) );
+		update_post_meta( $booking_id, '_booking_end', $this->_get_updated_timestamp_time( $end, $check_out ) );
+	}
+
+	/**
+	 * Update the time of a given datetime.
+	 *
+	 * @param string $datetime Date time without separator (YmdHis)
+	 * @param string $time     Time in `xx:yy` pm/am format
+	 *
+	 * @return Datetime without separtor
+	 */
+	protected function _get_updated_timestamp_time( $datetime, $time ) {
+		if ( empty( $time ) ) {
+			return $datetime;
+		}
+
+		$time  = str_replace( ':', '', $time );
+		$time  = str_pad( $time, 6, '0' );
+
+		return substr( $datetime, 0, 8 ) . $time;
+	}
 }
 
 new WC_Accommodation_Booking;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:  woothemes, jshreve, akeda
 Tags: woocommerce, bookings, accommodations
 Requires at least: 3.8
 Tested up to: 4.4
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -29,6 +29,9 @@ This extension extends Bookings and makes it possible to:
 Or use the automatic installation wizard through your admin panel, just search for this plugins name.
 
 == Changelog ==
+
+= 1.0.6 =
+* Fix - Check in/out time is not respected when booking is created
 
 = 1.0.5 =
 * Add - Display cost settings field.

--- a/woocommerce-accommodation-bookings.php
+++ b/woocommerce-accommodation-bookings.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce Accommodation Bookings
 Plugin URI: https://woocommerce.com/products/woocommerce-accommodation-bookings/
 Description: An accommodations add-on for the WooCommerce Bookings extension.
-Version: 1.0.5
+Version: 1.0.6
 Author: WooThemes
 Author URI: https://woocommerce.com
 Text Domain: woocommerce-accommodation-bookings
@@ -19,5 +19,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once( 'includes/class-wc-accommodation-bookings-plugin.php' );
-$plugin = new WC_Accommodation_Bookings_Plugin( __FILE__, '1.0.5' );
+$plugin = new WC_Accommodation_Bookings_Plugin( __FILE__, '1.0.6' );
 $plugin->run();


### PR DESCRIPTION
Updated time uses check in/out time. The value doesn't update the time
when existing booking is updated. Otherwiwe it always overrides what
ever user supplies.

Fixes #69.